### PR TITLE
Remove http schema from ETCD3_ENDPOINT if it exists

### DIFF
--- a/etcd3/__init__.py
+++ b/etcd3/__init__.py
@@ -25,6 +25,10 @@ def client():
         return _clt
 
     endpoint = os.getenv(ENV_ETCD3_ENDPOINT, '127.0.0.1:2379')
+    # Remove the schema if it exists (http://|https://)
+    if '//' in endpoint:
+        endpoint = endpoint.split('//')[1]
+
     user = os.getenv(ENV_ETCD3_USER)
     password = os.getenv(ENV_ETCD3_PASSWORD)
     cert_ca = os.getenv(ENV_ETCD3_CA)


### PR DESCRIPTION
## Purpose
Go implementation of the etcd client expects `ETCD3_ENDPOINT` in the https:// or http:// schema. This PR removes the `https://` prefix if it exists such that `ETCD3_ENDPOINT` is compatible with both the go and python implementations