### PR TITLE
Discover cluster endpoints and auto reconnect

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
 
 before_install:
   - ./scripts/etcd_start.sh
+  - sleep 5
   - ./scripts/etcd_init.sh
 
 install:

--- a/etcd3/_client.py
+++ b/etcd3/_client.py
@@ -1,23 +1,23 @@
 from __future__ import absolute_import
 
 import logging
+from random import shuffle
 from threading import Lock
 
 import grpc
+import six
 
 from etcd3 import _utils
 from etcd3._grpc_stubs.rpc_pb2 import (AuthStub, AuthenticateRequest,
-                                       DeleteRangeRequest, KVStub,
-                                       LeaseGrantRequest,
-                                       LeaseRevokeRequest, LeaseStub,
-                                       PutRequest, RangeRequest,
-                                       WatchStub)
+                                       ClusterStub, DeleteRangeRequest, KVStub,
+                                       LeaseGrantRequest, LeaseRevokeRequest,
+                                       LeaseStub, MemberListRequest, PutRequest,
+                                       RangeRequest, WatchStub)
 from etcd3._keep_aliver import KeepAliver
 from etcd3._watcher import Watcher
 
 _DEFAULT_ETCD_ENDPOINT = '127.0.0.1:23790'
 _DEFAULT_REQUEST_TIMEOUT = 1  # Seconds
-
 
 _log = logging.getLogger(__name__)
 
@@ -46,9 +46,9 @@ def _reconnect(f):
 
 class Client(object):
 
-    def __init__(self, endpoint, user, password, cert=None, cert_key=None,
+    def __init__(self, endpoints, user, password, cert=None, cert_key=None,
                  cert_ca=None, timeout=None):
-        self._endpoint = endpoint
+        self._endpoint_balancer = _EndpointBalancer(endpoints)
         self._user = user
         self._password = password
         self._ssl_creds = grpc.ssl_channel_credentials(
@@ -60,6 +60,13 @@ class Client(object):
         self._kv_stub = None
         self._watch_stub = None
         self._lease_stub = None
+
+        # For tests only!
+        self._skip_endpoint_discovery = False
+
+    @property
+    def current_endpoint(self):
+        return self._endpoint_balancer.current_endpoint
 
     @_reconnect
     def get(self, key, is_prefix=False):
@@ -123,6 +130,9 @@ class Client(object):
 
     def _ensure_grpc_channel(self):
         with self._grpc_channel_mu:
+            if self._grpc_channel:
+                return
+
             self._ensure_grpc_channel_unsafe()
 
     def _close_grpc_channel(self):
@@ -135,10 +145,15 @@ class Client(object):
             self._ensure_grpc_channel_unsafe()
 
     def _ensure_grpc_channel_unsafe(self):
-        if self._grpc_channel:
-            return
+        endpoint = self._endpoint_balancer.rotate_endpoint()
+        self._grpc_channel = self._dial(endpoint)
 
-        self._grpc_channel = self._dial()
+        if not self._skip_endpoint_discovery:
+            cluster_stub = ClusterStub(self._grpc_channel)
+            rs = cluster_stub.MemberList(MemberListRequest(),
+                                         timeout=self._timeout)
+            self._endpoint_balancer.refresh(rs.members, endpoint)
+
         self._kv_stub = KVStub(self._grpc_channel)
         self._watch_stub = WatchStub(self._grpc_channel)
         self._lease_stub = LeaseStub(self._grpc_channel)
@@ -153,16 +168,16 @@ class Client(object):
 
         self._grpc_channel = None
 
-    def _dial(self):
-        token = self._authenticate()
+    def _dial(self, endpoint):
+        token = self._authenticate(endpoint)
         token_plugin = _TokenAuthMetadataPlugin(token)
         token_creds = grpc.metadata_call_credentials(token_plugin)
         creds = grpc.composite_channel_credentials(self._ssl_creds,
                                                    token_creds)
-        return grpc.secure_channel(self._endpoint, creds)
+        return grpc.secure_channel(endpoint, creds)
 
-    def _authenticate(self):
-        grpc_channel = grpc.secure_channel(self._endpoint, self._ssl_creds)
+    def _authenticate(self, endpoint):
+        grpc_channel = grpc.secure_channel(endpoint, self._ssl_creds)
         try:
             auth_stub = AuthStub(grpc_channel)
             rq = AuthenticateRequest(
@@ -192,3 +207,49 @@ def _read_file(filename):
 
     with open(filename, 'rb') as f:
         return f.read()
+
+
+class _EndpointBalancer(object):
+
+    def __init__(self, endpoints):
+        self._mu = Lock()
+
+        if isinstance(endpoints, six.string_types):
+            endpoints = endpoints.split(',')
+
+        self._endpoints = [_normalize_endpoint(ep) for ep in endpoints]
+        shuffle(self._endpoints)
+
+    @property
+    def current_endpoint(self):
+        return self._endpoints[0]
+
+    def rotate_endpoint(self):
+        with self._mu:
+            rotated_endpoint = self._endpoints[0]
+            self._endpoints = self._endpoints[1:]
+            self._endpoints.append(rotated_endpoint)
+            return self._endpoints[0]
+
+    def refresh(self, members, current_endpoint):
+        with self._mu:
+            self._endpoints = []
+            for member in members:
+                if len(member.clientURLs) < 1:
+                    continue
+
+                endpoint = _normalize_endpoint(member.clientURLs[0])
+                if endpoint == current_endpoint:
+                    continue
+
+                self._endpoints.append(endpoint)
+
+            shuffle(self._endpoints)
+            # Ensure that current endpoint is the first in the list
+            self._endpoints.insert(0, current_endpoint)
+            _log.info('Endpoints refreshed: %s', self._endpoints)
+
+
+def _normalize_endpoint(ep):
+    parts = ep.lower().strip().split('//')
+    return parts[-1]

--- a/etcd3/_client.py
+++ b/etcd3/_client.py
@@ -33,6 +33,7 @@ def _reconnect(f):
                 return f(*args, **kwargs)
 
             except grpc.RpcError:
+                _log.exception('Retrying error: %s(*%s, **%s)', f, args, kwargs)
                 etcd3_clt._reset_grpc_channel()
                 return f(*args, **kwargs)
 

--- a/etcd3/_watcher.py
+++ b/etcd3/_watcher.py
@@ -19,6 +19,7 @@ class Watcher(object):
                  start_revision=0, spin_pause=None):
         self._client = client
         self._key = key
+        self._is_prefix = is_prefix
         self._start_revision = start_revision
         self._event_handler = event_handler
         self._spin_pause = spin_pause or _DEFAULT_SPIN_PAUSE
@@ -50,6 +51,10 @@ class Watcher(object):
         start_revision = None
         while not self._stop:
             try:
+                # Test if the key can be accessed. That is needed to trigger
+                # reconnects and also checks if there is enough permissions.
+                self._client.get(self._key, self._is_prefix)
+
                 watch_stub = self._client._get_watch_stub()
                 grpc_stream = GrpcBDStream(self._name + '_stream',
                                            watch_stub.Watch)

--- a/etcd3/_watcher.py
+++ b/etcd3/_watcher.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import logging
 from threading import Thread
+from time import sleep
 
 from etcd3 import _utils
 from etcd3._grpc_bd_stream import GrpcBDStream
@@ -48,17 +49,28 @@ class Watcher(object):
         _log.info('%s started', self._name)
         start_revision = None
         while not self._stop:
-            watch_stub = self._client._get_watch_stub()
-            grpc_stream = GrpcBDStream(self._name + '_stream', watch_stub.Watch)
-            if start_revision:
-                self._watch_rq.create_request.start_revision = start_revision
+            try:
+                watch_stub = self._client._get_watch_stub()
+                grpc_stream = GrpcBDStream(self._name + '_stream',
+                                           watch_stub.Watch)
+                if start_revision:
+                    self._watch_rq.create_request.start_revision = start_revision
 
-            grpc_stream.send(self._watch_rq, self._client._timeout)
+                grpc_stream.send(self._watch_rq, self._client._timeout)
+
+            except Exception:
+                _log.exception('Failed to initialize watch: %s', self._key)
+                sleep(self._spin_pause)
+                continue
+
             try:
                 while not self._stop:
                     rs = grpc_stream.recv(self._spin_pause)
                     if not rs:
                         continue
+
+                    if rs.created:
+                        _log.info('Watch created: %s', self._key)
 
                     for e in rs.events:
                         start_revision = e.kv.mod_revision + 1
@@ -70,6 +82,7 @@ class Watcher(object):
 
             except Exception:
                 _log.exception('Watch stream failed: %s', self._key)
+                sleep(self._spin_pause)
 
             finally:
                 grpc_stream.close(self._client._timeout)

--- a/scripts/defaults.sh
+++ b/scripts/defaults.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+export ETCD3_VERSION=${ETCD3_VERSION:=v3.3.8}
+export CLUSTER_SIZE=${CLUSTER_SIZE:=1}

--- a/scripts/defaults.sh
+++ b/scripts/defaults.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 export ETCD3_VERSION=${ETCD3_VERSION:=v3.3.8}
-export CLUSTER_SIZE=${CLUSTER_SIZE:=1}
+export CLUSTER_SIZE=${CLUSTER_SIZE:=3}

--- a/scripts/etcd_init.sh
+++ b/scripts/etcd_init.sh
@@ -2,6 +2,9 @@
 
 set -x
 
+SCRIPT_DIR="$(dirname $0)"
+source ${SCRIPT_DIR}/defaults.sh
+
 export ETCDCTL_API=3
 
 KERNEL_NAME=$(uname -s | awk '{print tolower($0)}')

--- a/scripts/etcd_start.sh
+++ b/scripts/etcd_start.sh
@@ -2,6 +2,9 @@
 
 set -x
 
+SCRIPT_DIR="$(dirname $0)"
+source ${SCRIPT_DIR}/defaults.sh
+
 KERNEL_NAME=$(uname -s | awk '{print tolower($0)}')
 ETCD3_DIST=etcd-${ETCD3_VERSION}-${KERNEL_NAME}-amd64
 if [[ "$KERNEL_NAME" =~ ^(darwin|windows)$ ]]; then
@@ -22,15 +25,35 @@ if [ ! -d ${WORKSPACE_DIR}/${ETCD3_DIST} ]; then
     tar -xzf ${WORKSPACE_DIR}/${ETCD3_ARCHIVE} -C ${WORKSPACE_DIR}
 fi
 
-${WORKSPACE_DIR}/${ETCD3_DIST}/etcd \
-    --name=test \
-    --listen-client-urls 'https://127.0.0.1:2379' \
-    --data-dir=${WORKSPACE_DIR}/data \
-    --advertise-client-urls 'https://127.0.0.1:2379' \
-    --cert-file=${FIXTURES_DIR}/localhost.pem \
-    --key-file=${FIXTURES_DIR}/localhost-key.pem \
-    &>${WORKSPACE_DIR}/etcd.log \
-    &
+INITIAL_CLUSTER="test1=http://127.0.0.1:2380"
+if (( ${CLUSTER_SIZE} > 1 )); then
+    for i in $(seq 2 ${CLUSTER_SIZE}); do
+        INITIAL_CLUSTER+=",test${i}=http://127.0.0.1:${i}2380"
+    done
+fi
 
-echo $! > ${WORKSPACE_DIR}/etcd.pid
-disown
+for i in $(seq 1 ${CLUSTER_SIZE}); do
+    client_port="2379"
+    peer_port="2380"
+    if (( ${i} > 1 )); then
+        client_port="${i}${client_port}"
+        peer_port="${i}${peer_port}"
+    fi
+    ${WORKSPACE_DIR}/${ETCD3_DIST}/etcd \
+        --name="test${i}" \
+        --listen-client-urls="https://127.0.0.1:${client_port}" \
+        --advertise-client-urls="https://127.0.0.1:${client_port}" \
+        --listen-peer-urls="http://127.0.0.1:${peer_port}" \
+        --initial-advertise-peer-urls="http://127.0.0.1:${peer_port}" \
+        --initial-cluster=${INITIAL_CLUSTER} \
+        --initial-cluster-state=new \
+        --data-dir=${WORKSPACE_DIR}/data${i} \
+        --cert-file=${FIXTURES_DIR}/localhost.pem \
+        --key-file=${FIXTURES_DIR}/localhost-key.pem \
+        &>${WORKSPACE_DIR}/etcd${i}.log \
+        &
+
+    echo $! > ${WORKSPACE_DIR}/etcd${i}.pid
+    disown
+done
+

--- a/scripts/etcd_stop.sh
+++ b/scripts/etcd_stop.sh
@@ -2,7 +2,12 @@
 
 set -x
 
+SCRIPT_DIR="$(dirname $0)"
+source ${SCRIPT_DIR}/defaults.sh
+
 WORKSPACE_DIR=tests/.workspace
 
-kill $(cat ${WORKSPACE_DIR}/etcd.pid)
-rm ${WORKSPACE_DIR}/etcd.pid
+for i in $(seq 1 ${CLUSTER_SIZE}); do
+    kill $(cat ${WORKSPACE_DIR}/etcd${i}.pid)
+    rm ${WORKSPACE_DIR}/etcd${i}.pid
+done

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='etcd3-slim',
-      version='0.1.6',
+      version='0.1.7',
       description='Thin Etcd3 client',
       long_description=open('README.md').read(),
       classifiers=[

--- a/tests/etcd3/_fixture.py
+++ b/tests/etcd3/_fixture.py
@@ -1,0 +1,104 @@
+from __future__ import absolute_import
+
+import os
+
+from etcd3 import (Client, ENV_ETCD3_CA, ENV_ETCD3_ENDPOINT, ENV_ETCD3_PASSWORD,
+                   ENV_ETCD3_USER)
+from tests.toxiproxy import ToxiProxyClient
+
+
+def setup():
+    global _toxi_proxy_clt
+    _toxi_proxy_clt = ToxiProxyClient()
+    _toxi_proxy_clt.start()
+
+    seed_endpoint = os.getenv(ENV_ETCD3_ENDPOINT, '127.0.0.1:2379')
+    user = os.getenv(ENV_ETCD3_USER, 'test')
+    password = os.getenv(ENV_ETCD3_PASSWORD, 'test')
+    cert_ca = os.getenv(ENV_ETCD3_CA, 'tests/fixtures/ca.pem')
+
+    global _direct_clt
+    _direct_clt = Client(seed_endpoint, user, password, cert_ca=cert_ca)
+
+    global _aux_clt
+    _aux_clt = Client(seed_endpoint, user, password, cert_ca=cert_ca)
+
+    _aux_clt._reset_grpc_channel()
+    discovered_endpoints = _aux_clt._endpoint_balancer._endpoints
+
+    global _proxy_endpoint_index
+    _proxy_endpoint_index = {}
+    proxy_endpoints = []
+    for i, discovered_endpoint in enumerate(discovered_endpoints):
+        proxy_name = str(i)
+        proxy_spec = _toxi_proxy_clt.add_proxy(proxy_name, discovered_endpoint)
+        proxy_endpoint = proxy_spec['listen']
+        # Make sure to access proxy via 127.0.0.1 otherwise TLS verification fails.
+        if proxy_endpoint.startswith('[::]:'):
+            proxy_endpoint = '127.0.0.1:' + proxy_endpoint[5:]
+
+        proxy_endpoints.append(proxy_endpoint)
+        _proxy_endpoint_index[proxy_endpoint] = proxy_name
+
+    # Proxied client is assumed to have not established a connection with Etcd.
+    global _proxied_clt
+    _proxied_clt = Client(proxy_endpoints, user, password, cert_ca=cert_ca)
+    _proxied_clt._skip_endpoint_discovery = True
+
+    # Clean leftovers from previous tests.
+    _aux_clt.delete('/test', is_prefix=True)
+
+
+def teardown():
+    _toxi_proxy_clt.stop()
+
+
+def proxied_clt():
+    """
+    Returns a client that connects to Etcd cluster though a toxi proxy that
+    can be controlled via enable/disable_endpoint(s) function family.
+    """
+    assert isinstance(_proxied_clt, Client)
+    return _proxied_clt
+
+
+def direct_clt():
+    """
+    Returns a client that connects to Etcd cluster directly.
+    """
+    assert isinstance(_direct_clt, Client)
+    return _direct_clt
+
+
+def aux_clt():
+    """
+    Returns a client that connects to Etcd cluster directly.
+    """
+    assert isinstance(_aux_clt, Client)
+    return _aux_clt
+
+
+def disable_endpoint(endpoint=None):
+    endpoint = endpoint or _proxied_clt.current_endpoint
+    _update_endpoints([endpoint], enabled=False)
+
+
+def enable_endpoint(endpoint=None):
+    endpoint = endpoint or _proxied_clt.current_endpoint
+    _update_endpoints([endpoint], enabled=True)
+
+
+def disable_all_endpoints():
+    _update_endpoints(endpoints=None, enabled=False)
+
+
+def enabled_all_endpoints():
+    _update_endpoints(endpoints=None, enabled=True)
+
+
+def _update_endpoints(endpoints, enabled):
+    for endpoint in endpoints or _proxy_endpoint_index.keys():
+        proxy_name = _proxy_endpoint_index[endpoint]
+        _toxi_proxy_clt.update_proxy(proxy_name, enabled)
+
+

--- a/tests/etcd3/keep_aliver_test.py
+++ b/tests/etcd3/keep_aliver_test.py
@@ -2,147 +2,155 @@ from __future__ import absolute_import
 
 from time import sleep
 
-import os
-from nose.tools import eq_
+from nose.tools import eq_, with_setup, assert_not_equal
 
-from etcd3 import (ENV_ETCD3_CA, ENV_ETCD3_ENDPOINT, ENV_ETCD3_PASSWORD,
-                   ENV_ETCD3_USER)
-from etcd3._client import Client
-from tests.toxiproxy import ToxiProxyClient
-
-_ETCD_PROXY = 'etcd'
+from tests.etcd3 import _fixture
 
 
-def setup_module():
-    global _toxi_proxy_clt
-    _toxi_proxy_clt = ToxiProxyClient()
-    _toxi_proxy_clt.start()
-
-    etcd_endpoint = os.getenv(ENV_ETCD3_ENDPOINT, '127.0.0.1:2379')
-    user = os.getenv(ENV_ETCD3_USER, 'test')
-    password = os.getenv(ENV_ETCD3_PASSWORD, 'test')
-    cert_ca = os.getenv(ENV_ETCD3_CA, 'tests/fixtures/ca.pem')
-
-    global _direct_clt
-    _direct_clt = Client(etcd_endpoint, user, password, cert_ca=cert_ca)
-
-    proxy_spec = _toxi_proxy_clt.add_proxy(_ETCD_PROXY, etcd_endpoint)
-    proxy_endpoint = proxy_spec['listen']
-    # Make sure to access proxy via 127.0.0.1 otherwise TLS verification fails.
-    if proxy_endpoint.startswith('[::]:'):
-        proxy_endpoint = '127.0.0.1:' + proxy_endpoint[5:]
-
-    global _proxied_clt
-    _proxied_clt = Client(proxy_endpoint, user, password, cert_ca=cert_ca)
-
-
-def teardown_module():
-    _toxi_proxy_clt.stop()
-
-
+@with_setup(_fixture.setup, _fixture.teardown)
 def test_normal_operation():
     # KeepAliver ensure that key exists while running and deletes it on stop.
 
-    _proxied_clt.delete('/test')
+    proxied_clt = _fixture.proxied_clt()
 
     ttl = 2
-    keep_aliver = _proxied_clt.new_keep_aliver('/test/keep-alive-0', 'bar', ttl,
-                                               spin_pause=0.2)
+    keep_aliver = proxied_clt.new_keep_aliver('/test/keep-alive-0', 'bar', ttl,
+                                              spin_pause=0.2)
     keep_aliver.start()
     try:
         for i in range(3):
             sleep(ttl - 0.5)
-            eq_(b'bar', _proxied_clt.get_value('/test/keep-alive-0'))
+            eq_(b'bar', proxied_clt.get_value('/test/keep-alive-0'))
 
     finally:
         eq_(True, keep_aliver.stop(timeout=3))
 
-    eq_(None, _proxied_clt.get_value('/test/keep-alive-0'))
+    eq_(None, proxied_clt.get_value('/test/keep-alive-0'))
 
 
+@with_setup(_fixture.setup, _fixture.teardown)
 def test_spin_pause_too_long():
     # Spin pause is adjusted if needed to be less then effective TTL.
 
-    _proxied_clt.delete('/test')
+    proxied_clt = _fixture.proxied_clt()
 
     ttl = 3
-    keep_aliver = _proxied_clt.new_keep_aliver('/test/keep-alive-1', 'bar', ttl,
-                                               spin_pause=10)
+    keep_aliver = proxied_clt.new_keep_aliver('/test/keep-alive-1', 'bar', ttl,
+                                              spin_pause=10)
     keep_aliver.start()
     try:
         sleep(ttl - 0.5)
-        eq_(b'bar', _proxied_clt.get_value('/test/keep-alive-1'))
+        eq_(b'bar', proxied_clt.get_value('/test/keep-alive-1'))
 
     finally:
         eq_(True, keep_aliver.stop(timeout=3))
 
-    eq_(None, _proxied_clt.get_value('/test/keep-alive-1'))
+    eq_(None, proxied_clt.get_value('/test/keep-alive-1'))
 
 
-def test_auto_reconnect():
-    # A keep alive object survives connection loses as long as they last less,
-    # then the lease TTL.
+@with_setup(_fixture.setup, _fixture.teardown)
+def test_auto_reconnect_node():
+    # If the node the client is connected to goes down, then the client
+    # recoonects to another node immediately.
 
-    _proxied_clt.delete('/test')
+    proxied_clt = _fixture.proxied_clt()
 
     ttl = 2
-    keep_aliver = _proxied_clt.new_keep_aliver('/test/keep-alive-2', 'bar', ttl,
-                                               spin_pause=0.2)
+    keep_aliver = proxied_clt.new_keep_aliver('/test/keep-alive-4', 'bar', ttl,
+                                              spin_pause=0.2)
     keep_aliver.start()
     try:
         sleep(ttl - 0.5)
-        eq_(b'bar', _proxied_clt.get_value('/test/keep-alive-2'))
+        eq_(b'bar', proxied_clt.get_value('/test/keep-alive-4'))
+        orig_endpoint = proxied_clt.current_endpoint
+
         sleep(ttl - 0.5)
-        eq_(b'bar', _proxied_clt.get_value('/test/keep-alive-2'))
+        eq_(b'bar', proxied_clt.get_value('/test/keep-alive-4'))
+        eq_(orig_endpoint, proxied_clt.current_endpoint)
+
+        # When
+        _fixture.disable_endpoint(orig_endpoint)
+
+        sleep(ttl - 0.5)
+        eq_(b'bar', proxied_clt.get_value('/test/keep-alive-4'))
+        assert_not_equal(orig_endpoint, proxied_clt.current_endpoint)
+        sleep(ttl - 0.5)
+        eq_(b'bar', proxied_clt.get_value('/test/keep-alive-4'))
+        sleep(ttl - 0.5)
+        eq_(b'bar', proxied_clt.get_value('/test/keep-alive-4'))
+
+    finally:
+        eq_(True, keep_aliver.stop(timeout=3))
+
+    eq_(None, proxied_clt.get_value('/test/keep-alive-4'))
+
+
+@with_setup(_fixture.setup, _fixture.teardown)
+def test_auto_reconnect_outage():
+    # If cluster wide outage lasts longer than the TTL, the key obviously
+    # expires, but it gets recreated after a connection is restored.
+
+    proxied_clt = _fixture.proxied_clt()
+
+    ttl = 2
+    keep_aliver = proxied_clt.new_keep_aliver('/test/keep-alive-2', 'bar', ttl,
+                                              spin_pause=0.2)
+    keep_aliver.start()
+    try:
+        sleep(ttl - 0.5)
+        eq_(b'bar', proxied_clt.get_value('/test/keep-alive-2'))
+        sleep(ttl - 0.5)
+        eq_(b'bar', proxied_clt.get_value('/test/keep-alive-2'))
 
         # If connection with Etcd is lost...
-        _toxi_proxy_clt.update_proxy(_ETCD_PROXY, enabled=False)
+        _fixture.disable_all_endpoints()
         # ...the key expires
         sleep(ttl + 0.5)
-        eq_(None, _direct_clt.get_value('/test/keep-alive-2'))
+        eq_(None, _fixture.aux_clt().get_value('/test/keep-alive-2'))
 
         # When: etcd gets back in service
-        _toxi_proxy_clt.update_proxy(_ETCD_PROXY, enabled=True)
+        _fixture.enabled_all_endpoints()
 
         # Then: the key is automatically restored.
         sleep(2)
-        eq_(b'bar', _proxied_clt.get_value('/test/keep-alive-2'))
+        eq_(b'bar', proxied_clt.get_value('/test/keep-alive-2'))
         sleep(ttl - 0.5)
-        eq_(b'bar', _proxied_clt.get_value('/test/keep-alive-2'))
+        eq_(b'bar', proxied_clt.get_value('/test/keep-alive-2'))
 
     finally:
         eq_(True, keep_aliver.stop(timeout=3))
 
-    eq_(None, _proxied_clt.get_value('/test/keep-alive-2'))
+    eq_(None, proxied_clt.get_value('/test/keep-alive-2'))
 
 
+@with_setup(_fixture.setup, _fixture.teardown)
 def test_etcd_down_on_start():
     # It is ok to create a keep_aliver when connection with Etcd is down. The
     # key will be created as soon as connection is restored.
 
-    _proxied_clt.delete('/test')
+    proxied_clt = _fixture.proxied_clt()
+
+    # Simulate Etcd down on start.
+    _fixture.disable_all_endpoints()
 
     ttl = 2
-    keep_aliver = _proxied_clt.new_keep_aliver('/test/keep-alive-3', 'bar', ttl,
-                                               spin_pause=0.2)
-    # Simulate Etcd down on start.
-    _toxi_proxy_clt.update_proxy(_ETCD_PROXY, enabled=False)
-
+    keep_aliver = proxied_clt.new_keep_aliver('/test/keep-alive-3', 'bar', ttl,
+                                              spin_pause=0.2)
     keep_aliver.start()
     try:
         sleep(0.5)
-        eq_(None, _direct_clt.get_value('/test/keep-alive-3'))
+        eq_(None, _fixture.aux_clt().get_value('/test/keep-alive-3'))
 
         # When: etcd gets back in service.
-        _toxi_proxy_clt.update_proxy(_ETCD_PROXY, enabled=True)
+        _fixture.enabled_all_endpoints()
 
         # Then: the key is automatically created.
         sleep(0.5)
-        eq_(b'bar', _proxied_clt.get_value('/test/keep-alive-3'))
+        eq_(b'bar', proxied_clt.get_value('/test/keep-alive-3'))
         sleep(ttl - 0.5)
-        eq_(b'bar', _proxied_clt.get_value('/test/keep-alive-3'))
+        eq_(b'bar', proxied_clt.get_value('/test/keep-alive-3'))
 
     finally:
         eq_(True, keep_aliver.stop(timeout=3))
 
-    eq_(None, _proxied_clt.get_value('/test/keep-alive-3'))
+    eq_(None, proxied_clt.get_value('/test/keep-alive-3'))

--- a/tests/etcd3/watcher_test.py
+++ b/tests/etcd3/watcher_test.py
@@ -169,9 +169,9 @@ def test_auto_reconnect():
 
         # But as soon as connection with Etcd is restored...
         _toxi_proxy_clt.update_proxy(_ETCD_PROXY, enabled=True)
-        sleep(0.5)
+
         # ...backed up events are received
-        events = _collect_events(watch_queue, timeout=3)
+        events = _collect_events(watch_queue, timeout=5)
         eq_(3, len(events))
         _assert_event(Event.PUT, '/test/foo', 'bar3', events[0])
         _assert_event(Event.DELETE, '/test/foo', '', events[1])
@@ -206,9 +206,9 @@ def test_etcd_down_on_start():
 
         # But as soon as connection with Etcd is restored...
         _toxi_proxy_clt.update_proxy(_ETCD_PROXY, enabled=True)
-        sleep(0.5)
+
         # ...backed up events are received
-        events = _collect_events(watch_queue, timeout=3)
+        events = _collect_events(watch_queue, timeout=5)
         eq_(3, len(events))
         _assert_event(Event.PUT, '/test/foo', 'bar1', events[0])
         _assert_event(Event.DELETE, '/test/foo', '', events[1])

--- a/tests/etcd3/watcher_test.py
+++ b/tests/etcd3/watcher_test.py
@@ -2,66 +2,35 @@ from __future__ import absolute_import
 
 from time import sleep
 
-import os
-from nose.tools import eq_
+from nose.tools import eq_, with_setup, assert_not_equal
 from six.moves import queue
 
-from etcd3 import (ENV_ETCD3_CA, ENV_ETCD3_ENDPOINT, ENV_ETCD3_PASSWORD,
-                   ENV_ETCD3_USER, _utils)
-from etcd3._client import Client
+from etcd3 import _utils
 from etcd3._grpc_stubs.kv_pb2 import Event
-from tests.toxiproxy import ToxiProxyClient
-
-_ETCD_PROXY = 'etcd'
+from tests.etcd3 import _fixture
 
 
-def setup_module():
-    global _toxi_proxy_clt
-    _toxi_proxy_clt = ToxiProxyClient()
-    _toxi_proxy_clt.start()
-
-    etcd_endpoint = os.getenv(ENV_ETCD3_ENDPOINT, '127.0.0.1:2379')
-    user = os.getenv(ENV_ETCD3_USER, 'test')
-    password = os.getenv(ENV_ETCD3_PASSWORD, 'test')
-    cert_ca = os.getenv(ENV_ETCD3_CA, 'tests/fixtures/ca.pem')
-
-    global _direct_clt
-    _direct_clt = Client(etcd_endpoint, user, password, cert_ca=cert_ca)
-
-    proxy_spec = _toxi_proxy_clt.add_proxy(_ETCD_PROXY, etcd_endpoint)
-    proxy_endpoint = proxy_spec['listen']
-    # Make sure to access proxy via 127.0.0.1 otherwise TLS verification fails.
-    if proxy_endpoint.startswith('[::]:'):
-        proxy_endpoint = '127.0.0.1:' + proxy_endpoint[5:]
-
-    global _proxied_clt
-    _proxied_clt = Client(proxy_endpoint, user, password, cert_ca=cert_ca)
-
-
-def teardown_module():
-    _toxi_proxy_clt.stop()
-
-
+@with_setup(_fixture.setup, _fixture.teardown)
 def test_watch_key():
-    _proxied_clt.delete('/test')
+    proxied_clt = _fixture.proxied_clt()
     watch_queue = queue.Queue()
 
-    _proxied_clt.put('/test/foo2', 'bar1')
-    w = _proxied_clt.new_watcher('/test/foo2', spin_pause=0.2,
-                                 event_handler=lambda e: watch_queue.put(e))
+    proxied_clt.put('/test/foo2', 'bar1')
+    w = proxied_clt.new_watcher('/test/foo2', spin_pause=0.2,
+                                event_handler=lambda e: watch_queue.put(e))
     w.start()
     try:
         sleep(0.5)
 
         # When
-        _proxied_clt.put('/test/foo1', 'bar2')
-        _proxied_clt.put('/test/foo3', 'bar5')
-        _proxied_clt.put('/test/foo2', 'bar6')
-        _proxied_clt.put('/test/foo21', 'bar7')
-        _proxied_clt.delete('/test/foo2')
-        _proxied_clt.put('/test/foo212', 'bar8')
-        _proxied_clt.put('/test/foo2', 'bar9')
-        _proxied_clt.put('/test/foo21', 'bar10')
+        proxied_clt.put('/test/foo1', 'bar2')
+        proxied_clt.put('/test/foo3', 'bar5')
+        proxied_clt.put('/test/foo2', 'bar6')
+        proxied_clt.put('/test/foo21', 'bar7')
+        proxied_clt.delete('/test/foo2')
+        proxied_clt.put('/test/foo212', 'bar8')
+        proxied_clt.put('/test/foo2', 'bar9')
+        proxied_clt.put('/test/foo21', 'bar10')
 
         # Then
         events = _collect_events(watch_queue, timeout=3)
@@ -74,25 +43,26 @@ def test_watch_key():
         w.stop(timeout=1)
 
 
+@with_setup(_fixture.setup, _fixture.teardown)
 def test_watch_key_prefix():
-    _proxied_clt.delete('/test')
+    proxied_clt = _fixture.proxied_clt()
     watch_queue = queue.Queue()
 
-    _proxied_clt.put('/test/foo2', 'bar1')
-    w = _proxied_clt.new_watcher('/test/foo2', is_prefix=True, spin_pause=0.2,
-                                 event_handler=lambda e: watch_queue.put(e))
+    proxied_clt.put('/test/foo2', 'bar1')
+    w = proxied_clt.new_watcher('/test/foo2', is_prefix=True, spin_pause=0.2,
+                                event_handler=lambda e: watch_queue.put(e))
     w.start()
     try:
         sleep(0.5)
 
         # When
-        _proxied_clt.put('/test/foo1', 'bar6')
-        _proxied_clt.put('/test/foo21', 'bar7')
-        _proxied_clt.delete('/test/foo2')
-        _proxied_clt.put('/test/foo212', 'bar8')
-        _proxied_clt.delete('/test/foo1')
-        _proxied_clt.put('/test/foo21', 'bar10')
-        _proxied_clt.put('/test/foo3', 'bar11')
+        proxied_clt.put('/test/foo1', 'bar6')
+        proxied_clt.put('/test/foo21', 'bar7')
+        proxied_clt.delete('/test/foo2')
+        proxied_clt.put('/test/foo212', 'bar8')
+        proxied_clt.delete('/test/foo1')
+        proxied_clt.put('/test/foo21', 'bar10')
+        proxied_clt.put('/test/foo3', 'bar11')
 
         # Then
         events = _collect_events(watch_queue, timeout=3)
@@ -106,26 +76,27 @@ def test_watch_key_prefix():
         w.stop(timeout=1)
 
 
+@with_setup(_fixture.setup, _fixture.teardown)
 def test_watch_from_the_past():
     # A revision to start watching from can be specified.
 
-    _proxied_clt.delete('/test')
+    proxied_clt = _fixture.proxied_clt()
     watch_queue = queue.Queue()
 
-    _proxied_clt.put('/test/foo2', 'bar1')
-    _proxied_clt.put('/test/foo2', 'bar2')
-    put_rs = _proxied_clt.put('/test/foo2', 'bar3')
-    _proxied_clt.put('/test/foo2', 'bar4')
-    _proxied_clt.put('/test/foo2', 'bar5')
-    _proxied_clt.put('/test/foo3', 'bar6')
+    proxied_clt.put('/test/foo2', 'bar1')
+    proxied_clt.put('/test/foo2', 'bar2')
+    put_rs = proxied_clt.put('/test/foo2', 'bar3')
+    proxied_clt.put('/test/foo2', 'bar4')
+    proxied_clt.put('/test/foo2', 'bar5')
+    proxied_clt.put('/test/foo3', 'bar6')
 
     # When
-    w = _proxied_clt.new_watcher('/test/foo2', spin_pause=0.2,
-                                 start_revision=put_rs.header.revision,
-                                 event_handler=lambda e: watch_queue.put(e))
+    w = proxied_clt.new_watcher('/test/foo2', spin_pause=0.2,
+                                start_revision=put_rs.header.revision,
+                                event_handler=lambda e: watch_queue.put(e))
     w.start()
     try:
-        _proxied_clt.delete('/test/foo2')
+        proxied_clt.delete('/test/foo2')
 
         # Then
         events = _collect_events(watch_queue, timeout=3)
@@ -139,36 +110,79 @@ def test_watch_from_the_past():
         w.stop(timeout=1)
 
 
-def test_auto_reconnect():
-    # A revision to start watching from can be specified.
+@with_setup(_fixture.setup, _fixture.teardown)
+def test_auto_reconnect_node():
+    # Watch is restored even after a cluster wide outage.
 
-    _proxied_clt.delete('/test')
+    proxied_clt = _fixture.proxied_clt()
     watch_queue = queue.Queue()
 
-    put_rs = _direct_clt.put('/test/foo', 'bar0')
-    w = _proxied_clt.new_watcher('/test/foo', spin_pause=0.2,
-                                 start_revision=put_rs.header.revision + 1,
-                                 event_handler=lambda e: watch_queue.put(e))
+    put_rs = _fixture.aux_clt().put('/test/foo', 'bar0')
+    w = proxied_clt.new_watcher('/test/foo', spin_pause=0.2,
+                                start_revision=put_rs.header.revision + 1,
+                                event_handler=lambda e: watch_queue.put(e))
     w.start()
     try:
-        _direct_clt.put('/test/foo', 'bar1')
-        _direct_clt.put('/test/foo', 'bar2')
+        _fixture.aux_clt().put('/test/foo', 'bar1')
+        events = _collect_events(watch_queue, timeout=3)
+        eq_(1, len(events))
+
+        orig_endpoint = proxied_clt.current_endpoint
+        _fixture.aux_clt().put('/test/foo', 'bar2')
+        _fixture.aux_clt().put('/test/foo', 'bar3')
+        _fixture.aux_clt().put('/test/foo', 'bar4')
+        events = _collect_events(watch_queue, timeout=3)
+        eq_(3, len(events))
+        eq_(orig_endpoint, proxied_clt.current_endpoint)
+
+        # When
+        _fixture.disable_endpoint(orig_endpoint)
+
+        # Then: immediately reconnected to another endpoint.
+        _fixture.aux_clt().delete('/test/foo')
+        _fixture.aux_clt().put('/test/foo', 'bar5')
+        events = _collect_events(watch_queue, timeout=3)
+        eq_(2, len(events))
+        _assert_event(Event.DELETE, '/test/foo', '', events[0])
+        _assert_event(Event.PUT, '/test/foo', 'bar5', events[1])
+
+        assert_not_equal(orig_endpoint, proxied_clt.current_endpoint)
+
+    finally:
+        w.stop(timeout=1)
+
+
+@with_setup(_fixture.setup, _fixture.teardown)
+def test_auto_reconnect_outage():
+    # Watch is restored even after a cluster wide outage.
+
+    proxied_clt = _fixture.proxied_clt()
+    watch_queue = queue.Queue()
+
+    put_rs = _fixture.aux_clt().put('/test/foo', 'bar0')
+    w = proxied_clt.new_watcher('/test/foo', spin_pause=0.2,
+                                start_revision=put_rs.header.revision + 1,
+                                event_handler=lambda e: watch_queue.put(e))
+    w.start()
+    try:
+        _fixture.aux_clt().put('/test/foo', 'bar1')
+        _fixture.aux_clt().put('/test/foo', 'bar2')
         sleep(0.5)
 
         # When connection with Etcd is lost...
-        _toxi_proxy_clt.update_proxy(_ETCD_PROXY, enabled=False)
+        _fixture.disable_all_endpoints()
 
         # New events stop coming.
-        _direct_clt.put('/test/foo', 'bar3')
-        _direct_clt.delete('/test/foo')
-        _direct_clt.put('/test/foo', 'bar4')
+        _fixture.aux_clt().put('/test/foo', 'bar3')
+        _fixture.aux_clt().delete('/test/foo')
+        _fixture.aux_clt().put('/test/foo', 'bar4')
         events = _collect_events(watch_queue, timeout=3)
         eq_(2, len(events))
         _assert_event(Event.PUT, '/test/foo', 'bar1', events[0])
         _assert_event(Event.PUT, '/test/foo', 'bar2', events[1])
 
-        # But as soon as connection with Etcd is restored...
-        _toxi_proxy_clt.update_proxy(_ETCD_PROXY, enabled=True)
+        # But as soon as the cluster is back in service...
+        _fixture.enabled_all_endpoints()
 
         # ...backed up events are received
         events = _collect_events(watch_queue, timeout=5)
@@ -181,23 +195,24 @@ def test_auto_reconnect():
         w.stop(timeout=1)
 
 
+@with_setup(_fixture.setup, _fixture.teardown)
 def test_etcd_down_on_start():
     # If connection with Etcd cannot be established when a watch is started,
     # then events are received as soon as the connection is up.
 
-    _proxied_clt.delete('/test')
+    proxied_clt = _fixture.proxied_clt()
     watch_queue = queue.Queue()
 
-    put_rs = _proxied_clt.put('/test/foo', 'bar1')
-    _proxied_clt.delete('/test/foo')
-    _proxied_clt.put('/test/foo', 'bar2')
+    put_rs = proxied_clt.put('/test/foo', 'bar1')
+    proxied_clt.delete('/test/foo')
+    proxied_clt.put('/test/foo', 'bar2')
 
-    w = _proxied_clt.new_watcher('/test/foo', spin_pause=0.2,
-                                 start_revision=put_rs.header.revision,
-                                 event_handler=lambda e: watch_queue.put(e))
+    w = proxied_clt.new_watcher('/test/foo', spin_pause=0.2,
+                                start_revision=put_rs.header.revision,
+                                event_handler=lambda e: watch_queue.put(e))
 
     # When connection with Etcd is lost...
-    _toxi_proxy_clt.update_proxy(_ETCD_PROXY, enabled=False)
+    _fixture.disable_all_endpoints()
 
     w.start()
     try:
@@ -205,7 +220,7 @@ def test_etcd_down_on_start():
         eq_(0, len(events))
 
         # But as soon as connection with Etcd is restored...
-        _toxi_proxy_clt.update_proxy(_ETCD_PROXY, enabled=True)
+        _fixture.enabled_all_endpoints()
 
         # ...backed up events are received
         events = _collect_events(watch_queue, timeout=5)
@@ -218,10 +233,11 @@ def test_etcd_down_on_start():
         w.stop(timeout=1)
 
 
+@with_setup(_fixture.setup, _fixture.teardown)
 def test_handler_exception():
     # Event handler failures do not disrupt watch operation.
 
-    _proxied_clt.delete('/test')
+    proxied_clt = _fixture.proxied_clt()
     watch_queue = queue.Queue()
 
     handle_count = [0]
@@ -233,17 +249,17 @@ def test_handler_exception():
 
         watch_queue.put(e)
 
-    put_rs = _direct_clt.put('/test/foo', 'bar0')
-    w = _proxied_clt.new_watcher('/test/foo', spin_pause=0.2,
-                                 start_revision=put_rs.header.revision + 1,
-                                 event_handler=event_handler)
+    put_rs = _fixture.aux_clt().put('/test/foo', 'bar0')
+    w = proxied_clt.new_watcher('/test/foo', spin_pause=0.2,
+                                start_revision=put_rs.header.revision + 1,
+                                event_handler=event_handler)
     w.start()
     try:
         # When
-        _proxied_clt.put('/test/foo', 'bar1')
-        _proxied_clt.put('/test/foo', 'bar2')
-        _proxied_clt.put('/test/foo', 'bar3')
-        _proxied_clt.put('/test/foo', 'bar4')
+        proxied_clt.put('/test/foo', 'bar1')
+        proxied_clt.put('/test/foo', 'bar2')
+        proxied_clt.put('/test/foo', 'bar3')
+        proxied_clt.put('/test/foo', 'bar4')
 
         # Then
         events = _collect_events(watch_queue, timeout=3)


### PR DESCRIPTION
Client was made to discover all cluster member nodes given a comma separated list (or just one node) of seed nodes. If a node it is connected to goes down, Client reconnects to an arbitrary node. 

It also fixes an issue discovered in production that call `self._client._get_watch_stub()` starts failing after about 30 seconds of connection loss. In tests I could not reproduce the same behavior. It is always `grpc_stream.recv(self._spin_pause)` that fails, this one also fails in production but only for the first 30 seconds.