### PR TITLE
Add curl to the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /work
 
 RUN \
     apk update && \
-    apk add bash
+    apk add bash curl
 
 COPY . \
     /work/


### PR DESCRIPTION
The etcd-start script will fetch etcd if no archive is present, but curl
has to be installed into the container for that to actually work.