### PR TITLE
PIP-711: Skip auth if disabled

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(name='etcd3-slim',
       ],
       install_requires=[
           'enum34;python_version<"3.4"',
-          'grpcio',
-          'protobuf',
+          'grpcio==1.20.1',
+          'protobuf==3.7.1',
           'six'
       ])


### PR DESCRIPTION
## Purpose
If we decide to disable authentication on the etcd server, etcd client should continue to connect even if the USER/PASSWORD is provided.